### PR TITLE
Usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,52 +161,60 @@ contains usage of the `SampleDistributor`, the `data_generator` module, the `Eff
 and the `Annotations` class to calculate annotator reliability.
 
 ```python
+import os
+
+from effiara.annotator_reliability import Annotations
 from effiara.data_generator import (
     annotate_samples,
     concat_annotations,
     generate_samples,
 )
-from effiara.preparation import SampleDistributor
-from effiara.annotator_reliability import Annotations
 from effiara.effi_label_generator import EffiLabelGenerator
+from effiara.preparation import SampleDistributor
 
 # example for creating set of samples, annotations, and sticking them together
 if __name__ == "__main__":
+    os.makedirs("data", exist_ok=True)
 
     annotator_dict = {
-        "user_1": 0.95,
-        "user_2": 0.67,
-        "user_3": 0.58,
-        "user_4": 0.63,
-        "user_5": 0.995,
-        "user_6": 0.45,
+        "user_aa": 0.95,
+        "user_bb": 0.67,
+        "user_cc": 0.58,
+        "user_dd": 0.63,
+        "user_ee": 0.995,
+        "user_ff": 0.45,
     }
+    annotator_names = [k.split('_')[-1] for k in annotator_dict.keys()]
 
     sample_distributor = SampleDistributor(
-        num_annotators=len(annotator_dict),
+        #num_annotators=len(annotator_dict),
+        annotators=annotator_names,
         time_available=10,
         annotation_rate=60,
         # num_samples=2160,
-        double_proportion=1/3,
-        re_proportion=1/2,
+        double_proportion=1 / 3,
+        re_proportion=1 / 2,
     )
     sample_distributor.set_project_distribution()
     print(sample_distributor)
 
     num_classes = 3
-    df = generate_samples(sample_distributor, num_classes)
+    df = generate_samples(sample_distributor, num_classes, seed=0)
     sample_distributor.distribute_samples(df.copy(), "./data", all_reannotation=True)
 
-    annotate_samples(sample_distributor, annotator_dict, "./data", num_classes)
-    annotations = concat_annotations("./data/annotations", len(annotator_dict))
+    annotate_samples(annotator_dict, "./data", num_classes)
+    annotations = concat_annotations("./data/annotations", annotator_names)
     print(annotations)
 
     label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
-    label_generator = EffiLabelGenerator(6, label_mapping)
-    effiannos = Annotations(annotations, label_generator, agreement_metric="cohen")
-    effiannos.calculate_annotator_reliability()
+    label_generator = EffiLabelGenerator(6, label_mapping, annotators=annotator_names)
+    effiannos = Annotations(annotations, label_generator)
     print(effiannos.get_reliability_dict())
-    print(effiannos.overall_inter_annotator_agreement)
-    effiannos.display_annotator_graph()
-
+    #effiannos.display_annotator_graph()
+    # Equivalent to the graph, but as a heatmap
+    effiannos.display_agreement_heatmap()
+    # Agreements between two subsets of annotators
+    effiannos.display_agreement_heatmap(
+            annotators=effiannos.annotators[:4],
+            other_annotators=effiannos.annotators[3:])
 ```

--- a/examples/synthetic_single_label.py
+++ b/examples/synthetic_single_label.py
@@ -1,3 +1,5 @@
+import os
+
 from effiara.annotator_reliability import Annotations
 from effiara.data_generator import (
     annotate_samples,
@@ -9,18 +11,21 @@ from effiara.preparation import SampleDistributor
 
 # example for creating set of samples, annotations, and sticking them together
 if __name__ == "__main__":
+    os.makedirs("data", exist_ok=True)
 
     annotator_dict = {
-        "user_1": 0.95,
-        "user_2": 0.67,
-        "user_3": 0.58,
-        "user_4": 0.63,
-        "user_5": 0.995,
-        "user_6": 0.45,
+        "user_aa": 0.95,
+        "user_bb": 0.67,
+        "user_cc": 0.58,
+        "user_dd": 0.63,
+        "user_ee": 0.995,
+        "user_ff": 0.45,
     }
+    annotator_names = [k.split('_')[-1] for k in annotator_dict.keys()]
 
     sample_distributor = SampleDistributor(
-        num_annotators=len(annotator_dict),
+        #num_annotators=len(annotator_dict),
+        annotators=annotator_names,
         time_available=10,
         annotation_rate=60,
         # num_samples=2160,
@@ -31,16 +36,21 @@ if __name__ == "__main__":
     print(sample_distributor)
 
     num_classes = 3
-    df = generate_samples(sample_distributor, num_classes)
+    df = generate_samples(sample_distributor, num_classes, seed=0)
     sample_distributor.distribute_samples(df.copy(), "./data", all_reannotation=True)
 
     annotate_samples(annotator_dict, "./data", num_classes)
-    annotations = concat_annotations("./data/annotations", len(annotator_dict))
+    annotations = concat_annotations("./data/annotations", annotator_names)
     print(annotations)
 
     label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
-    label_generator = EffiLabelGenerator(6, label_mapping)
+    label_generator = EffiLabelGenerator(6, label_mapping, annotators=annotator_names)
     effiannos = Annotations(annotations, label_generator)
-    effiannos.calculate_annotator_reliability()
     print(effiannos.get_reliability_dict())
-    effiannos.display_annotator_graph()
+    #effiannos.display_annotator_graph()
+    # Equivalent to the graph, but as a heatmap
+    effiannos.display_agreement_heatmap()
+    # Agreements between two subsets of annotators
+    effiannos.display_agreement_heatmap(
+            annotators=effiannos.annotators[:4],
+            other_annotators=effiannos.annotators[3:])

--- a/examples/synthetic_single_label.py
+++ b/examples/synthetic_single_label.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 
 from effiara.annotator_reliability import Annotations
 from effiara.data_generator import (
@@ -11,12 +12,17 @@ from effiara.preparation import SampleDistributor
 
 # example for creating set of samples, annotations, and sticking them together
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--usernames",action="store_true", default=False)
+    args = parser.parse_args()
+
     os.makedirs("data", exist_ok=True)
 
-    # Percentage correctness for each annotator.
-    annotators = None
     # If annotators is None, names are set to integers in SampleDistributor.
-    #annotators = ["aa", "bb", "cc", "dd", "ee", "ff"]
+    annotators = None
+    if args.usernames is True:
+        annotators = ["aa", "bb", "cc", "dd", "ee", "ff"]
+    # Percentage correctness for each annotator.
     correctness = [0.95, 0.67, 0.58, 0.63, 0.995, 0.45]
 
     sample_distributor = SampleDistributor(

--- a/examples/synthetic_single_label.py
+++ b/examples/synthetic_single_label.py
@@ -13,19 +13,15 @@ from effiara.preparation import SampleDistributor
 if __name__ == "__main__":
     os.makedirs("data", exist_ok=True)
 
-    annotator_dict = {
-        "user_aa": 0.95,
-        "user_bb": 0.67,
-        "user_cc": 0.58,
-        "user_dd": 0.63,
-        "user_ee": 0.995,
-        "user_ff": 0.45,
-    }
-    annotator_names = [k.split('_')[-1] for k in annotator_dict.keys()]
+    # Percentage correctness for each annotator.
+    annotators = None
+    # If annotators is None, names are set to integers in SampleDistributor.
+    #annotators = ["aa", "bb", "cc", "dd", "ee", "ff"]
+    correctness = [0.95, 0.67, 0.58, 0.63, 0.995, 0.45]
 
     sample_distributor = SampleDistributor(
-        #num_annotators=len(annotator_dict),
-        annotators=annotator_names,
+        annotators=annotators,
+        num_annotators=len(correctness),
         time_available=10,
         annotation_rate=60,
         # num_samples=2160,
@@ -39,15 +35,17 @@ if __name__ == "__main__":
     df = generate_samples(sample_distributor, num_classes, seed=0)
     sample_distributor.distribute_samples(df.copy(), "./data", all_reannotation=True)
 
+    annotator_dict = dict(zip(sample_distributor.annotators, correctness))
+    print(annotator_dict)
     annotate_samples(annotator_dict, "./data", num_classes)
-    annotations = concat_annotations("./data/annotations", annotator_names)
+    annotations = concat_annotations("./data/annotations", sample_distributor.annotators)
     print(annotations)
 
     label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
-    label_generator = EffiLabelGenerator(6, label_mapping, annotators=annotator_names)
+    label_generator = EffiLabelGenerator(sample_distributor.annotators, label_mapping)
     effiannos = Annotations(annotations, label_generator)
     print(effiannos.get_reliability_dict())
-    #effiannos.display_annotator_graph()
+    effiannos.display_annotator_graph()
     # Equivalent to the graph, but as a heatmap
     effiannos.display_agreement_heatmap()
     # Agreements between two subsets of annotators

--- a/src/effiara/annotator_reliability.py
+++ b/src/effiara/annotator_reliability.py
@@ -1,11 +1,16 @@
+import warnings
+from itertools import combinations, product
+
 import matplotlib.pyplot as plt
 import networkx as nx
 import numpy as np
+import seaborn as sns
 
 from effiara.agreement import pairwise_agreement
+from effiara.utils import retrieve_pair_annotations
 
 
-class Annotations:
+class Annotations(object):
     """Class to hold all annotation information for the EffiARA annotation
     framework. Methods include inter- and intra- annotator agreement
     calculations, as well the overall reliability calculation and other
@@ -21,6 +26,7 @@ class Annotations:
     ):
         # set instance variables
         self.label_generator = label_generator
+        self.annotators = label_generator.annotators
         self.num_annotators = label_generator.num_annotators
         self.label_mapping = label_generator.label_mapping
         self.num_classes = label_generator.num_classes
@@ -39,13 +45,11 @@ class Annotations:
         # generate user soft labels
         self.df = self.label_generator.add_annotation_prob_labels(self.df)
 
-        # calculate intra annotator
+        # calculate agreements
         self.G = self.init_annotator_graph()
-
         self.calculate_intra_annotator_agreement()
-
-        # calculate inter_annotator agreement
         self.calculate_inter_annotator_agreement()
+        self.calculate_annotator_reliability()
 
     def replace_labels(self):
         """Merge labels. Uses find and replace so do not switch labels e.g.
@@ -54,25 +58,23 @@ class Annotations:
         if not self.merge_labels:
             return
 
-        # TODO: generalise so you can replace all columns that might have something
         for replacement, to_replace in self.merge_labels.items():
             for label in to_replace:
-                for i in range(1, self.num_annotators + 1):
-                    # each label col
-                    label_col = f"user_{i}_label"
+                for user in self.annotators:
+                    label_col = f"user_{user}_label"
                     re_label_col = "re_" + label_col
-                    secondary_col = f"user_{i}_secondary"
+                    secondary_col = f"user_{user}_secondary"
                     re_secondary_col = "re_" + secondary_col
 
                     # find and replace in each col
-                    self.df[label_col] = self.df[label_col].replace(label, replacement)
+                    self.df[label_col] = self.df[label_col].replace(label, replacement)  # noqa
                     self.df[secondary_col] = self.df[secondary_col].replace(
                         label, replacement
                     )
                     self.df[re_label_col] = self.df[re_label_col].replace(
                         label, replacement
                     )
-                    self.df[re_secondary_col] = self.df[re_secondary_col].replace(
+                    self.df[re_secondary_col] = self.df[re_secondary_col].replace(  # noqa
                         label, replacement
                     )
 
@@ -89,8 +91,8 @@ class Annotations:
         This means each annotator will initially be weighted equally.
         """
         G = nx.Graph()
-        for i in range(1, self.num_annotators + 1):
-            G.add_node(f"user_{i}", reliability=1)
+        for user in self.annotators:
+            G.add_node(f"user_{user}", reliability=1)
         return G
 
     def normalise_edge_property(self, property):
@@ -105,8 +107,7 @@ class Annotations:
         avg = total / num_edges
         if avg < 0:
             raise ValueError(
-                "Mean value must be greater than zero, high agreement/reliability will become low and vice versa."
-            )
+                "Mean value must be greater than zero, high agreement/reliability will become low and vice versa.")  # noqa
 
         for _, _, edge in self.G.edges(data=True):
             edge[property] /= avg
@@ -123,50 +124,47 @@ class Annotations:
         avg = total / num_nodes
         if avg < 0:
             raise ValueError(
-                "Mean value must be greater than zero, high agreement/reliability will become low and vice versa."
-            )
+                "Mean value must be greater than zero, high agreement/reliability will become low and vice versa.")  # noqa
 
         for node in self.G.nodes():
             self.G.nodes[node][property] /= avg
 
-    def calculate_inter_annotator_agreement(self):
+    def calculate_inter_annotator_agreement(self, threshold=30):
         """Calculate the inter-annotator agreement between each
         pair of annotators. Each agreement value will be
         represented on the edges of the graph between nodes
         that are representative of each annotator.
+
+        Args:
+            threshold (int): threshold number of samples required
+                for a link to be made between two annotators.
+
         """
         inter_annotator_agreement_scores = {}
-        for i in range(self.num_annotators):
-            # get the current annotators and 2 linked
-            current_annotator = f"user_{i+1}"
-            link_1_annotator = f"user_{(i+1) % self.num_annotators + 1}"
-            link_2_annotator = f"user_{(i+2) % self.num_annotators + 1}"
+        pairs = combinations(self.annotators, 2)
+        for (user1, user2) in pairs:
+            current_annotator = f"user_{user1}"
+            link_annotator = f"user_{user2}"
 
-            # update inter annotator agreement scores
-            inter_annotator_agreement_scores[(current_annotator, link_1_annotator)] = (
-                pairwise_agreement(
-                    self.df,
-                    current_annotator,
-                    link_1_annotator,
-                    self.label_mapping,
-                    num_classes=self.num_classes,
-                    metric=self.agreement_metric,
+            # TODO: optimise use of pair df rather than generate twice
+            pair_df = retrieve_pair_annotations(
+                    self.df, current_annotator, link_annotator)
+            if len(pair_df) >= threshold:
+                pair = (current_annotator, link_annotator)
+                inter_annotator_agreement_scores[pair] = (
+                    pairwise_agreement(
+                        self.df,
+                        current_annotator,
+                        link_annotator,
+                        self.label_mapping,
+                        num_classes=self.num_classes,
+                        metric=self.agreement_metric,
+                    )
                 )
-            )
-            inter_annotator_agreement_scores[(current_annotator, link_2_annotator)] = (
-                pairwise_agreement(
-                    self.df,
-                    current_annotator,
-                    link_2_annotator,
-                    self.label_mapping,
-                    num_classes=self.num_classes,
-                    metric=self.agreement_metric,
-                )
-            )
 
-            # add all agreement scores to the graph
-            for users, score in inter_annotator_agreement_scores.items():
-                self.G.add_edge(users[0], users[1], agreement=score)
+        # add all agreement scores to the graph
+        for users, score in inter_annotator_agreement_scores.items():
+            self.G.add_edge(users[0], users[1], agreement=score)
 
         self.overall_inter_annotator_agreement = np.mean(
             list(inter_annotator_agreement_scores.values())
@@ -174,11 +172,11 @@ class Annotations:
 
     def calculate_intra_annotator_agreement(self):
         """Calculate intra-annotator agreement."""
-        for i in range(self.num_annotators):
-            user_name = f"user_{i+1}"
-            re_user_name = f"re_user_{i+1}"
+        for user in self.annotators:
+            user_name = f"user_{user}"
+            re_user_name = f"re_user_{user}"
             try:
-                self.G.nodes[user_name]["intra_agreement"] = pairwise_agreement(
+                self.G.nodes[user_name]["intra_agreement"] = pairwise_agreement(  # noqa
                     self.df,
                     user_name,
                     re_user_name,
@@ -187,9 +185,8 @@ class Annotations:
                     metric=self.agreement_metric,
                 )
             except KeyError:
-                print(
-                    "WARNING: Key error for calculating intra-annotator agreement. Setting all intra-annotator agreement values to 1."
-                )
+                warnings.warn(
+                    "Key error for calculating intra-annotator agreement. Setting all intra-annotator agreement values to 1.")  # noqa
                 self.G.nodes[user_name]["intra_agreement"] = 1
             except Exception as e:
                 self.G.nodes[user_name]["intra_agreement"] = 1
@@ -214,16 +211,17 @@ class Annotations:
                 weighted_agreement_sum / weights_sum if weights_sum else 0
             )
 
-    def calculate_annotator_reliability(self, alpha=0.5, beta=0.5, epsilon=0.001):
+    def calculate_annotator_reliability(
+            self, alpha=0.5, beta=0.5, epsilon=0.001):
         """Recursively calculate annotator reliability, using
            intra-annotator agreement, inter-annotator agreement,
            or a mixture, controlled by the alpha and beta parameters.
            Alpha and Beta must sum to 1.0.
 
         Args:
-            alpha (float): value between 0 and 1, controlling weight of intra-annotator agreement.
-            beta (float): value between 0 and 1, controlling weight of inter-annotator agreement.
-            epsilon (float): controls the maximum change from the last iteration to indicate convergence.
+            alpha (float): value between 0 and 1, controlling weight of intra-annotator agreement.  # noqa
+            beta (float): value between 0 and 1, controlling weight of inter-annotator agreement.  # noqa
+            epsilon (float): controls the maximum change from the last iteration to indicate convergence.  # noqa
         """
         if alpha + beta != 1:
             raise ValueError("Alpha and Beta must sum to 1.0.")
@@ -236,23 +234,24 @@ class Annotations:
         while abs(max_change) > epsilon:
             print("Running iteration.")
             previous_reliabilties = {
-                node: data["reliability"] for node, data in self.G.nodes(data=True)
-            }
+                    node: data["reliability"]
+                    for (node, data) in self.G.nodes(data=True)}
 
             # calculate the new inter annotator agreement scores
             self.calculate_avg_inter_annotator_agreement()
 
             # update reliability
             for _, node in self.G.nodes(data=True):
-                node["reliability"] = float(
-                    alpha * node["intra_agreement"] + beta * node["avg_inter_agreement"]
-                )
+                intra = node["intra_agreement"]
+                inter = node["avg_inter_agreement"]
+                rel = float(alpha * intra + beta * inter)
+                node["reliability"] = rel
             self.normalise_node_property("reliability")
 
             # find largest change as a marker
             max_change = max(
                 [
-                    abs(self.G.nodes[node]["reliability"] - previous_reliabilties[node])
+                    abs(self.G.nodes[node]["reliability"] - previous_reliabilties[node])  # noqa
                     for node in self.G.nodes()
                 ]
             )
@@ -274,7 +273,8 @@ class Annotations:
         Returns:
             dict: dictionary of key=username, value=reliability.
         """
-        return {node: self.G.nodes[node]["reliability"] for node in self.G.nodes()}
+        return {node: self.G.nodes[node]["reliability"]
+                for node in self.G.nodes()}
 
     def display_annotator_graph(self, legend=False):
         """Display the annotation graph."""
@@ -284,16 +284,18 @@ class Annotations:
         node_size = 3000
         nx.draw_networkx_nodes(self.G, pos, node_size=node_size)
         nx.draw_networkx_edges(self.G, pos)
-        labels = {node: node[-1] for node in self.G.nodes()}
+        # Get the usernames.
+        labels = {node: node.split('_', maxsplit=1)[-1]
+                  for node in self.G.nodes()}
         nx.draw_networkx_labels(
             self.G, pos, labels=labels, font_color="white", font_size=24
         )
 
         # add inter-annotator agreement to edges
-        edge_labels = {
-            (u, v): f"{d['agreement']:.3f}" for u, v, d in self.G.edges(data=True)
-        }
-        nx.draw_networkx_edge_labels(self.G, pos, edge_labels=edge_labels, font_size=24)
+        edge_labels = {(u, v): f"{d['agreement']:.3f}"
+                       for u, v, d in self.G.edges(data=True)}
+        nx.draw_networkx_edge_labels(
+                self.G, pos, edge_labels=edge_labels, font_size=24)
 
         # adjust text pos for intra-annotator agreement
         for node, (x, y) in pos.items():
@@ -324,12 +326,11 @@ class Annotations:
 
         # legend for reliability
         if legend:
-            reliability_scores = {
-                node: data["reliability"] for node, data in self.G.nodes(data=True)
-            }
-            reliability_text = "Reliability:\n\n" + "\n".join(
-                [f"{node}: {score:.3f}" for node, score in reliability_scores.items()]
-            )
+            reliability_scores = {node: data["reliability"]
+                                  for (node, data) in self.G.nodes(data=True)}
+            texts = [f"{node}: {score:.3f}"
+                     for (node, score) in reliability_scores.items()]
+            reliability_text = "Reliability:\n\n" + "\n".join(texts)
             plt.text(
                 0.05,
                 0.95,
@@ -343,6 +344,62 @@ class Annotations:
 
         # plot
         plt.axis("off")
+        plt.show()
+
+    def display_agreement_heatmap(
+            self,
+            annotators: list = None,
+            other_annotators: list = None):
+        """
+        Plot a heatmap of agreement metric values for the annotators.
+
+        annotators, other_annotators: (Optional) If both are specified
+            compare users given in annotators to those in other_annotators.
+            Otherwise, compare all project annotators to each other.
+        """
+        mat = nx.to_numpy_array(self.G, weight="agreement")
+        # Put intra-agreements on the diagonal
+        intras = nx.get_node_attributes(self.G, "intra_agreement")
+        intras = np.array(list(intras.values()))
+        mat[np.diag_indices(mat.shape[0])] = intras
+        agreements = self.G.nodes(data="avg_inter_agreement")
+        if annotators is not None and other_annotators is not None:
+            matrows = [i for (i, user) in enumerate(self.annotators)
+                       if user in annotators]
+            matcols = [i for (i, user) in enumerate(self.annotators)
+                       if user in other_annotators]
+            # If we're comparing two sets of annotators,
+            # slice the agreement matrix.
+            mat = mat[matrows][:, matcols]
+            agreements = [(name, agree) for (name, agree) in agreements
+                          if name.split('_', maxsplit=1)[1] in annotators]
+
+
+        sorted_by_agreement = sorted(enumerate(agreements),
+                                     key=lambda n: n[1][1], reverse=True)
+        ordered_row_idxs = [i for (i, _) in sorted_by_agreement]
+        mat = mat[ordered_row_idxs]
+
+        # We now have two possible cases.
+        #  1) annotators and other_annotators == None: We're comparing
+        #     each annotator to each other. In this case we'll display
+        #     only the lower triangle of the agreement heatmap as the
+        #     the upper triangle will be identical to the lower.
+        #  2) otherwise, we're comparing two possibly distinct sets of
+        #     annotators, so we display the full matrix, with rows and
+        #     columns sliced according to the annotators specified.
+        sorted_users = [user.split('_', maxsplit=1)[1]
+                        for (i, (user, agree)) in sorted_by_agreement]
+        if other_annotators is None:
+            mat = mat[:, ordered_row_idxs]
+            # Don't display upper triangle, since its redundant.
+            mat[np.triu_indices(mat.shape[0], k=1)] = np.nan
+            xlabs = ylabs = sorted_users
+        else:
+            xlabs = other_annotators
+            ylabs = sorted_users
+        sns.heatmap(mat, annot=True, fmt='.3f',
+                    xticklabels=xlabs, yticklabels=ylabs)
         plt.show()
 
     def __str__(self):

--- a/src/effiara/data_generator.py
+++ b/src/effiara/data_generator.py
@@ -1,5 +1,6 @@
 import os
 from functools import reduce
+from typing import List
 
 import numpy as np
 import pandas as pd
@@ -27,9 +28,8 @@ def generate_annotator_label(
         return np.random.choice(list(set(range(num_classes)) - {true_label}))
 
 
-def generate_samples(
-    sample_distributor: SampleDistributor, num_classes: int
-) -> pd.DataFrame:
+def generate_samples(sample_distributor: SampleDistributor,
+                     num_classes: int, seed=None) -> pd.DataFrame:
     """Generate a set of anntotations to be tested in annotator
        reliability assessment. Allows control over how good each
        annotator should be, allowing the assessment of the annotation
@@ -43,6 +43,8 @@ def generate_samples(
     # current annotator single annotations
     assert sample_distributor.num_samples is not None
     num_samples = round(1.5 * sample_distributor.num_samples)
+    if seed is not None:
+        np.random.seed(seed)
     true_labels = np.random.randint(0, num_classes, size=num_samples)
     dataset = pd.DataFrame({"true_label": true_labels})
 
@@ -162,18 +164,19 @@ def user_df_merge(left: pd.DataFrame, right: pd.DataFrame) -> pd.DataFrame:
     return merged
 
 
-def concat_annotations(annotation_path: str, num_annotators: int):
+def concat_annotations(annotation_path: str,
+                       annotators: List[str]):
     """Concatenate annotations based on sample_id.
 
     Args:
         annotation_path (str): path to dir containing csv annotations.
-        num_annotators (int): number of annotators.
+        annotators list(str): list of annotator names.
 
     Returns:
         pd.DataFrame: dataframe containing all annotations.
     """
     df_list = [
-        pd.read_csv(f"{annotation_path}/user_{i+1}.csv") for i in range(num_annotators)
+        pd.read_csv(f"{annotation_path}/user_{name}.csv") for name in annotators
     ]
     annotations = reduce(user_df_merge, df_list)
     return annotations

--- a/src/effiara/effi_label_generator.py
+++ b/src/effiara/effi_label_generator.py
@@ -118,9 +118,8 @@ class EffiLabelGenerator(LabelGenerator):
         row_annotators = []
         # loop through each annotator
         for user in self.annotators:
-            prefix = f"user_{user}"
             # check if user has a soft label column that isn't NaN
-            if isinstance(row[f"{prefix}_soft_label"], np.ndarray):
+            if isinstance(row[f"{user}_soft_label"], np.ndarray):
                 # if so, append prefix to row_annotators list
                 row_annotators.append(prefix)
 
@@ -156,7 +155,7 @@ class EffiLabelGenerator(LabelGenerator):
             row [pd.Series]: Row containing generated soft labels.
         """
         for user in self.annotators:
-            valid_user_prefixes = [f"user_{user}", f"re_user_{user}"]
+            valid_user_prefixes = [user, f"re_{user}"]
 
             for prefix in valid_user_prefixes:
                 row[f"{prefix}_soft_label"] = self._create_user_soft_label(
@@ -171,7 +170,7 @@ class EffiLabelGenerator(LabelGenerator):
 
         Args:
             row (pd.Series): a single row of the full annotation DataFrame.
-            user_prefix (str): user's prefix in the form user_x or re_user_x.
+            user_prefix (str): user's prefix in the form username or re_username.
 
         Returns:
             np.ndarray: vector of soft labels, with each dimension representing probability

--- a/src/effiara/effi_label_generator.py
+++ b/src/effiara/effi_label_generator.py
@@ -117,8 +117,8 @@ class EffiLabelGenerator(LabelGenerator):
         # TODO: convert to list comprehension?
         row_annotators = []
         # loop through each annotator
-        for i in range(1, self.num_annotators + 1):
-            prefix = f"user_{i}"
+        for user in self.annotators:
+            prefix = f"user_{user}"
             # check if user has a soft label column that isn't NaN
             if isinstance(row[f"{prefix}_soft_label"], np.ndarray):
                 # if so, append prefix to row_annotators list
@@ -155,8 +155,8 @@ class EffiLabelGenerator(LabelGenerator):
         Returns:
             row [pd.Series]: Row containing generated soft labels.
         """
-        for i in range(1, self.num_annotators + 1):
-            valid_user_prefixes = [f"user_{i}", f"re_user_{i}"]
+        for user in self.annotators:
+            valid_user_prefixes = [f"user_{user}", f"re_user_{user}"]
 
             for prefix in valid_user_prefixes:
                 row[f"{prefix}_soft_label"] = self._create_user_soft_label(

--- a/src/effiara/label_generator.py
+++ b/src/effiara/label_generator.py
@@ -2,8 +2,6 @@ from abc import ABC, abstractmethod
 
 import pandas as pd
 
-from effiara.utils import check_user_format
-
 
 class LabelGenerator(ABC):
     """Abstract class for generation of labels for set of annotations."""
@@ -11,8 +9,6 @@ class LabelGenerator(ABC):
     def __init__(self,
                  annotators: list,
                  label_mapping: dict):
-        for name in annotators:
-            check_user_format(name, prefixed=False)
         self.annotators = annotators
         self.num_annotators = len(self.annotators)
         self.label_mapping = label_mapping

--- a/src/effiara/label_generator.py
+++ b/src/effiara/label_generator.py
@@ -6,8 +6,18 @@ import pandas as pd
 class LabelGenerator(ABC):
     """Abstract class for generation of labels for set of annotations."""
 
-    def __init__(self, num_annotators: int, label_mapping: dict):
+    def __init__(self,
+                 num_annotators: int,
+                 label_mapping: dict,
+                 annotators: list = None):
         self.num_annotators = num_annotators
+        # Set annotators to list of ints if not given.
+        if annotators is None:
+            self.annotators = list(range(1, self.num_annotators + 1))
+        else:
+            self.annotators = annotators
+            if len(self.annotators) != self.num_annotators:
+                raise ValueError(f"Number of annotator names ({len(annotators)}) != num_annotators ({num_annotators})!")
         self.label_mapping = label_mapping
         self.num_classes = len(label_mapping)
 

--- a/src/effiara/label_generator.py
+++ b/src/effiara/label_generator.py
@@ -2,22 +2,19 @@ from abc import ABC, abstractmethod
 
 import pandas as pd
 
+from effiara.utils import check_user_format
+
 
 class LabelGenerator(ABC):
     """Abstract class for generation of labels for set of annotations."""
 
     def __init__(self,
-                 num_annotators: int,
-                 label_mapping: dict,
-                 annotators: list = None):
-        self.num_annotators = num_annotators
-        # Set annotators to list of ints if not given.
-        if annotators is None:
-            self.annotators = list(range(1, self.num_annotators + 1))
-        else:
-            self.annotators = annotators
-            if len(self.annotators) != self.num_annotators:
-                raise ValueError(f"Number of annotator names ({len(annotators)}) != num_annotators ({num_annotators})!")
+                 annotators: list,
+                 label_mapping: dict):
+        for name in annotators:
+            check_user_format(name, prefixed=False)
+        self.annotators = annotators
+        self.num_annotators = len(self.annotators)
         self.label_mapping = label_mapping
         self.num_classes = len(label_mapping)
 

--- a/src/effiara/preparation.py
+++ b/src/effiara/preparation.py
@@ -16,6 +16,7 @@ from sympy.core.symbol import Symbol
 def sample_without_replacement(
     df: pd.DataFrame, n: int
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
+    n = min([len(df), n])
     sampled_df = df.sample(n)
     return df.drop(sampled_df.index.to_list()), sampled_df
 
@@ -167,7 +168,7 @@ class SampleDistributor:
     def distribute_samples(
         self,
         df: pd.DataFrame,
-        save_path: str,
+        save_path: str = None,
         all_reannotation: bool = False,
     ):
         """Distribute samples based on sample distributor
@@ -249,6 +250,10 @@ class SampleDistributor:
 
                 annotations_dict[current_annotator].append(second_double_samples)
                 annotations_dict[link_2_annotator].append(second_double_samples)
+
+        if save_path is None:
+            annotations_dict["left_over"] = df
+            return annotations_dict
 
         for user, df_list in annotations_dict.items():
             # concat all user's dataframes

--- a/src/effiara/preparation.py
+++ b/src/effiara/preparation.py
@@ -12,8 +12,6 @@ import pandas as pd
 from sympy import Eq, solve, symbols
 from sympy.core.symbol import Symbol
 
-from effiara.utils import check_user_format
-
 
 def sample_without_replacement(
     df: pd.DataFrame, n: int
@@ -78,13 +76,9 @@ class SampleDistributor:
             re_proportion,
         )
         if annotators is None:
-            self.annotators = [str(i) for i in range(1, self.num_annotators + 1)]
+            self.annotators = [f"user_{i}" for i in range(1, self.num_annotators + 1)]
         else:
-            # Check that annotators do not have any prefixes.
-            for name in annotators:
-                check_user_format(name, prefixed=False)
             self.annotators = annotators
-        self.prefixed_annotators = [f"user_{name}" for name in self.annotators]
 
     def _assign_variables(self, variables: dict):
         """Assign class level variables from dict of symbolised
@@ -193,7 +187,9 @@ class SampleDistributor:
             df (pd.DataFrame): dataframe containing samples with
                 each row being a separate sample - using a copy
                 is recommended.
-            save_path (str): dir path to save all data to.
+            save_path (str): (Optional) If not None, dir path to save all data to.
+                             If not supplied, a dict of allocations is returned.
+                             Default None.
             all_reannotation (bool): whether re-annotations should be sampled
                 from all the user's annotations rather than just single
                 annotations. In this case, a double annotation project amount
@@ -225,15 +221,10 @@ class SampleDistributor:
 
         # TODO: maybe add some handling of save path?
         for (i, current_annotator) in enumerate(self.annotators):
-            #current_annotator = f"user_{user}"
             link_1_idx = (i+1) % self.num_annotators
             link_2_idx = (i+2) % self.num_annotators
             link_1_annotator = self.annotators[link_1_idx]
             link_2_annotator = self.annotators[link_2_idx]
-            #user_1 = self.annotators[link_1_idx]
-            #user_2 = self.annotators[link_2_idx]
-            #link_1_annotator = f"user_{user_1}"
-            #link_2_annotator = f"user_{user_2}"
             re_annotation_samples = None
 
             # single annotations
@@ -283,7 +274,7 @@ class SampleDistributor:
                 re_annotation_samples["is_reannotation"] = True
                 user_df = pd.concat([user_df, re_annotation_samples], ignore_index=True)  # noqa
             # save df
-            user_df.to_csv(f"{save_path}/user_{user}.csv", index=False)
+            user_df.to_csv(f"{save_path}/{user}.csv", index=False)
 
         # save all left over samples
         df.to_csv(f"{save_path}/left_over.csv", index=False)

--- a/src/effiara/preparation.py
+++ b/src/effiara/preparation.py
@@ -5,9 +5,8 @@ This includes:
     * calculating the distribution of samples
 """
 
-from typing import Optional
+from typing import Optional, List
 
-import numpy as np
 import pandas as pd
 from sympy import Eq, solve, symbols
 from sympy.core.symbol import Symbol
@@ -55,6 +54,7 @@ class SampleDistributor:
 
     def __init__(
         self,
+        annotators: Optional[List[str]] = None,
         num_annotators: Optional[int] = None,
         time_available: Optional[float] = None,
         annotation_rate: Optional[float] = None,
@@ -62,6 +62,9 @@ class SampleDistributor:
         double_proportion: Optional[float] = None,
         re_proportion: Optional[float] = None,
     ):
+        self.annotators = annotators
+        if self.annotators is not None:
+            num_annotators = len(annotators)
         self.get_variables(
             num_annotators,
             time_available,
@@ -70,6 +73,8 @@ class SampleDistributor:
             double_proportion,
             re_proportion,
         )
+        if self.annotators is None:
+            self.annotators = list(range(1, self.num_annotators + 1))
 
     def _assign_variables(self, variables: dict):
         """Assign class level variables from dict of symbolised
@@ -141,16 +146,16 @@ class SampleDistributor:
         """Set project distributions once all values have been
         defined.
         """
-        assert self.num_annotators is not None, "num_annotators must be set"
-        assert self.num_samples is not None, "num_samples must be set"
-        assert self.double_proportion is not None, "double_proportion must be set"
-        assert self.re_proportion is not None, "re_proportion must be set"
+        assert self.num_annotators is not None, "num_annotators must be set"  # noqa
+        assert self.num_samples is not None, "num_samples must be set"  # noqa
+        assert self.double_proportion is not None, "double_proportion must be set"  # noqa
+        assert self.re_proportion is not None, "re_proportion must be set"  # noqa
 
         self.double_annotation_project = round(
-            (self.double_proportion * self.num_samples) / (2 * self.num_annotators)
+            (self.double_proportion * self.num_samples) / (2 * self.num_annotators)  # noqa
         )
         self.single_annotation_project = round(
-            ((1 - self.double_proportion) * self.num_samples) / self.num_annotators
+            ((1 - self.double_proportion) * self.num_samples) / self.num_annotators  # noqa
         )
         self.re_annotation_project = round(
             self.re_proportion * self.single_annotation_project
@@ -189,7 +194,7 @@ class SampleDistributor:
         assert (
             self.double_annotation_project is not None
         ), "double_annotation_project must be set"
-        assert self.double_proportion is not None, "double_proportion must be set"
+        assert self.double_proportion is not None, "double_proportion must be set"  # noqa
         assert (
             self.single_annotation_project is not None
         ), "single_annotation_project must be set"
@@ -199,22 +204,24 @@ class SampleDistributor:
 
         if len(df) < self.num_samples:
             raise ValueError(
-                f"DataFrame does not contain enough samples. len(df) [{len(df)}] < num_samples [{self.num_samples}]."
+                f"DataFrame does not contain enough samples. len(df) [{len(df)}] < num_samples [{self.num_samples}]."  # noqa
             )
 
         # add sample_id to allow final dataset compilation
         df["sample_id"] = range(len(df))
 
         # create annotator dict
-        annotations_dict = {f"user_{i+1}": [] for i in range(self.num_annotators)}
+        annotations_dict = {f"user_{user}": [] for user in self.annotators}
 
         # TODO: maybe add some handling of save path?
-        for i in range(self.num_annotators):
-            current_annotator = f"user_{i+1}"
-            link_1_idx = (i+1) % self.num_annotators + 1
-            link_2_idx = (i+2) % self.num_annotators + 1
-            link_1_annotator = f"user_{link_1_idx}"
-            link_2_annotator = f"user_{link_2_idx}"
+        for (i, user) in enumerate(self.annotators):
+            current_annotator = f"user_{user}"
+            link_1_idx = (i+1) % self.num_annotators
+            link_2_idx = (i+2) % self.num_annotators
+            user_1 = self.annotators[link_1_idx]
+            user_2 = self.annotators[link_2_idx]
+            link_1_annotator = f"user_{user_1}"
+            link_2_annotator = f"user_{user_2}"
             re_annotation_samples = None
 
             # single annotations
@@ -231,7 +238,7 @@ class SampleDistributor:
                         self.re_annotation_project
                     )
                     re_annotation_samples["is_reannotation"] = True
-                    annotations_dict[current_annotator].append(re_annotation_samples)
+                    annotations_dict[current_annotator].append(re_annotation_samples)  # noqa
 
             # double annotations
             if self.double_annotation_project > 0:
@@ -240,16 +247,16 @@ class SampleDistributor:
                 )
                 first_double_samples["is_reannotation"] = False
 
-                annotations_dict[current_annotator].append(first_double_samples)
-                annotations_dict[link_1_annotator].append(first_double_samples)
+                annotations_dict[current_annotator].append(first_double_samples)  # noqa
+                annotations_dict[link_1_annotator].append(first_double_samples)  # noqa
 
                 df, second_double_samples = sample_without_replacement(
                     df, self.double_annotation_project
                 )
                 second_double_samples["is_reannotation"] = False
 
-                annotations_dict[current_annotator].append(second_double_samples)
-                annotations_dict[link_2_annotator].append(second_double_samples)
+                annotations_dict[current_annotator].append(second_double_samples)  # noqa
+                annotations_dict[link_2_annotator].append(second_double_samples)  # noqa
 
         if save_path is None:
             annotations_dict["left_over"] = df
@@ -260,9 +267,9 @@ class SampleDistributor:
             user_df = pd.concat(df_list, ignore_index=True)
             # sample from all if not from singles
             if all_reannotation:
-                re_annotation_samples = user_df.sample(self.double_annotation_project)
+                re_annotation_samples = user_df.sample(self.double_annotation_project)  # noqa
                 re_annotation_samples["is_reannotation"] = True
-                user_df = pd.concat([user_df, re_annotation_samples], ignore_index=True)
+                user_df = pd.concat([user_df, re_annotation_samples], ignore_index=True)  # noqa
             # save df
             user_df.to_csv(f"{save_path}/{user}.csv", index=False)
 

--- a/src/effiara/preparation.py
+++ b/src/effiara/preparation.py
@@ -210,8 +210,10 @@ class SampleDistributor:
         # TODO: maybe add some handling of save path?
         for i in range(self.num_annotators):
             current_annotator = f"user_{i+1}"
-            link_1_annotator = f"user_{(i+1) % 6 + 1}"
-            link_2_annotator = f"user_{(i+2) % 6 + 1}"
+            link_1_idx = (i+1) % self.num_annotators + 1
+            link_2_idx = (i+2) % self.num_annotators + 1
+            link_1_annotator = f"user_{link_1_idx}"
+            link_2_annotator = f"user_{link_2_idx}"
             re_annotation_samples = None
 
             # single annotations

--- a/src/effiara/utils.py
+++ b/src/effiara/utils.py
@@ -3,26 +3,6 @@ import re
 import numpy as np
 
 
-def check_user_format(user_x, prefixed=True):
-    """Check that user is in the correct format of
-    the string user_{username} or re_user_{username}.
-
-    Args:
-        prefixed (bool): If True, checks that user_x has a (re_)user_ prefix.
-                         If False, checks that user_x does NOT have the prefix.
-                         Default True.
-    """
-    matched = re.match(r"(re_)?user_\w+", user_x)
-    if prefixed is True:
-        passed = matched is not None
-        error_str = "User name must be in the form user_x or re_user_x, where x is some string. Got '{user_x}'."
-    else:
-        passed = matched is None
-        error_str = "User name must not have a '(re_)user_' prefix. Got '{user_x}'."
-    if passed is False:
-        raise ValueError(error_str)
-
-
 def is_prob_label(x, num_classes):
     """Check that a value is a soft label (nd vector).
 
@@ -66,8 +46,6 @@ def retrieve_pair_annotations(df, user_x, user_y):
         pd.DataFrame: copy of the reduced subset containing
                       only samples annotated by both users.
     """
-    check_user_format(user_x)
-    check_user_format(user_y)
     return df[df[f"{user_x}_label"].notna() & df[f"{user_y}_label"].notna()].copy()
 
 

--- a/src/effiara/utils.py
+++ b/src/effiara/utils.py
@@ -3,15 +3,24 @@ import re
 import numpy as np
 
 
-def check_user_format(user_x):
+def check_user_format(user_x, prefixed=True):
     """Check that user is in the correct format of
     the string user_{username} or re_user_{username}.
+
+    Args:
+        prefixed (bool): If True, checks that user_x has a (re_)user_ prefix.
+                         If False, checks that user_x does NOT have the prefix.
+                         Default True.
     """
     matched = re.match(r"(re_)?user_\w+", user_x)
-    if matched is None:
-        raise ValueError(
-            "User parameters must be in the form user_x or re_user_x, where x is some string. Got '{user_x}'."
-        )
+    if prefixed is True:
+        passed = matched is not None
+        error_str = "User name must be in the form user_x or re_user_x, where x is some string. Got '{user_x}'."
+    else:
+        passed = matched is None
+        error_str = "User name must not have a '(re_)user_' prefix. Got '{user_x}'."
+    if passed is False:
+        raise ValueError(error_str)
 
 
 def is_prob_label(x, num_classes):

--- a/src/effiara/utils.py
+++ b/src/effiara/utils.py
@@ -5,9 +5,13 @@ import numpy as np
 
 def check_user_format(user_x):
     """Check that user is in the correct format of
-    the string user_{some_number} or re_user_{some_number}.
+    the string user_{username} or re_user_{username}.
     """
-    return bool(re.match(r"(re_)?user_\d+", user_x))
+    matched = re.match(r"(re_)?user_\w+", user_x)
+    if matched is None:
+        raise ValueError(
+            "User parameters must be in the form user_x or re_user_x, where x is some string. Got '{user_x}'."
+        )
 
 
 def is_prob_label(x, num_classes):
@@ -53,15 +57,8 @@ def retrieve_pair_annotations(df, user_x, user_y):
         pd.DataFrame: copy of the reduced subset containing
                       only samples annotated by both users.
     """
-    if not check_user_format(user_x):
-        raise ValueError(
-            "User x parameters must be in the form user_x or re_user_x, where x is some number."
-        )
-    if not check_user_format(user_y):
-        raise ValueError(
-            "User y parameters must be in the form user_y or re_user_y, where y is some number."
-        )
-
+    check_user_format(user_x)
+    check_user_format(user_y)
     return df[df[f"{user_x}_label"].notna() & df[f"{user_y}_label"].notna()].copy()
 
 


### PR DESCRIPTION
This branch adds support for optional annotator names. Overall, annotator names are always expected to not contain the `(re_)user_` prefix, and I've added checks for this throughout the pipeline. If annotator names are not given, everything defaults to integer indices as were previously used. I've updated `examples/synthetic_single_label.py` to show the new usage.

Additional changes follow:

1. `SampleDistributor.distribute_samples()` returns the dict of allocations if `save_path` is not given.
2. Added a new method `display_agreement_heatmap()` to the `Annotations` class. This heatmap is equivalent to and more readable than the graph for large numbers of annotators. It also includes an option to compare two different sets of annotators.
3. `utils.check_user_format()` now raises a ValueError instead of returning a bool. There is also now an option `prefixed`, which allows one to check if the username _does not_ have a `user_` prefix. The default value of this option (`prefixed=True`) does not change functionality from previous versions.