### PR TITLE
Feature/ordinal annotations

### DIFF
--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -1,11 +1,11 @@
-from effiara.preparation import SampleDistributor
 from effiara.annotator_reliability import Annotations
+from effiara.data_generator import (
+    annotate_samples,
+    concat_annotations,
+    generate_samples,
+)
 from effiara.label_generators import DefaultLabelGenerator  # noqa
-
-from effiara.data_generator import (generate_samples,
-                                    annotate_samples,
-                                    concat_annotations)
-
+from effiara.preparation import SampleDistributor
 
 # Generate some random data to annotate.
 num_classes = 3
@@ -27,27 +27,27 @@ sample_distributor = SampleDistributor(
     # This is unknown. SampleDistributor will solve for it.
     annotation_rate=None,
     num_samples=num_samples,
-    double_proportion=1/3,
-    re_proportion=1/2,
+    double_proportion=1 / 3,
+    re_proportion=1 / 2,
 )
 sample_distributor.set_project_distribution()
 print(sample_distributor)
 # Distribute the samples to the annotators.
-allocations = sample_distributor.distribute_samples(
-   df.copy(), all_reannotation=True)
+allocations = sample_distributor.distribute_samples(df.copy())
 
 # Generate annotations according to allocations and annotator correctness.
 annotated = annotate_samples(allocations, annotator_dict, num_classes)
 annotations = concat_annotations(annotated)
 print(annotations)
 
+
 # Compute reliability metrics.
-effiannos = Annotations(annotations, num_classes)
+effiannos = Annotations(annotations, reannotations=True)
 # You can also define a label_generator manually like so,
 # if you need more advanced functionality.
-#label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
-#label_generator = DefaultLabelGenerator(annotators, label_mapping)
-#effiannos = Annotations(annotations, num_classes,
+# label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
+# label_generator = DefaultLabelGenerator(annotators, label_mapping)
+# effiannos = Annotations(annotations, num_classes,
 #                         label_generator=label_generator)
 print(effiannos.get_reliability_dict())
 

--- a/examples/redistribute_examples.py
+++ b/examples/redistribute_examples.py
@@ -1,11 +1,11 @@
-from effiara.preparation import SampleDistributor, SampleRedistributor
 from effiara.annotator_reliability import Annotations
+from effiara.data_generator import (
+    annotate_samples,
+    concat_annotations,
+    generate_samples,
+)
 from effiara.label_generators import DefaultLabelGenerator  # noqa
-
-from effiara.data_generator import (generate_samples,
-                                    annotate_samples,
-                                    concat_annotations)
-
+from effiara.preparation import SampleDistributor, SampleRedistributor
 
 # Generate some random data to annotate.
 num_classes = 3
@@ -27,14 +27,13 @@ sample_distributor = SampleDistributor(
     # This is unknown. SampleDistributor will solve for it.
     annotation_rate=None,
     num_samples=num_samples,
-    double_proportion=1/3,
-    re_proportion=1/2,
+    double_proportion=1 / 3,
+    re_proportion=1 / 2,
 )
 sample_distributor.set_project_distribution()
 print(sample_distributor)
 # Distribute the samples to the annotators.
-allocations = sample_distributor.distribute_samples(
-   df.copy(), all_reannotation=True)
+allocations = sample_distributor.distribute_samples(df.copy())
 
 # Generate annotations according to allocations and annotator correctness.
 annotated = annotate_samples(allocations, annotator_dict, num_classes)
@@ -42,19 +41,18 @@ annotations = concat_annotations(annotated)
 print(annotations)
 
 # Compute reliability metrics.
-effiannos = Annotations(annotations, num_classes)
+effiannos = Annotations(annotations, reannotations=True)
 print(effiannos.get_reliability_dict())
 
 effiannos.display_agreement_heatmap()
 
 print("Re-Annotating")
-sample_redistributor = SampleRedistributor.from_sample_distributor(
-        sample_distributor)
+sample_redistributor = SampleRedistributor.from_sample_distributor(sample_distributor)
 sample_redistributor.set_project_distribution()
 reallocations = sample_redistributor.distribute_samples(annotations)
 reannotated = annotate_samples(reallocations, annotator_dict, num_classes)
 reannotations = concat_annotations(reannotated)
 print(reannotations)
-effi_reannos = Annotations(reannotations, num_classes)
+effi_reannos = Annotations(reannotations, reannotations=True)
 print(effi_reannos.get_reliability_dict())
 effi_reannos.display_agreement_heatmap()

--- a/examples/synthetic_single_label.py
+++ b/examples/synthetic_single_label.py
@@ -9,7 +9,6 @@ from effiara.data_generator import (
 from effiara.label_generators.effi_label_generator import EffiLabelGenerator
 from effiara.preparation import SampleDistributor
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument("--usernames", action="store_true", default=False)
 args = parser.parse_args()
@@ -31,13 +30,12 @@ sample_distributor = SampleDistributor(
     time_available=10,
     annotation_rate=None,
     num_samples=num_samples,
-    double_proportion=1/3,
-    re_proportion=1/2,
+    double_proportion=1 / 3,
+    re_proportion=1 / 2,
 )
 sample_distributor.set_project_distribution()
 print(sample_distributor)
-allocations = sample_distributor.distribute_samples(
-    df.copy(), all_reannotation=True)
+allocations = sample_distributor.distribute_samples(df.copy())
 
 annotator_dict = dict(zip(sample_distributor.annotators, correctness))
 annotated = annotate_samples(allocations, annotator_dict, num_classes)
@@ -45,14 +43,13 @@ annotations = concat_annotations(annotated)
 print(annotations)
 
 label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
-label_generator = EffiLabelGenerator(
-    sample_distributor.annotators, label_mapping)
-effiannos = Annotations(annotations, len(label_mapping), label_generator)
+label_generator = EffiLabelGenerator(sample_distributor.annotators, label_mapping)
+effiannos = Annotations(annotations, label_generator, reannotations=True)
 print(effiannos.get_reliability_dict())
 effiannos.display_annotator_graph()
 # Equivalent to the graph, but as a heatmap
 effiannos.display_agreement_heatmap()
 # Agreements between two subsets of annotators
 effiannos.display_agreement_heatmap(
-        annotators=effiannos.annotators[:4],
-        other_annotators=effiannos.annotators[3:])
+    annotators=effiannos.annotators[:4], other_annotators=effiannos.annotators[3:]
+)

--- a/src/effiara/label_generators/ordinal_label_generator.py
+++ b/src/effiara/label_generators/ordinal_label_generator.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import numpy as np
+
+from effiara.label_generators import LabelGenerator
+
+
+class OrdinalLabelGenerator(LabelGenerator):
+
+    def __init__(self, annotators: list, label_mapping: dict, label_suffixes=["_label"]):
+        super().__init__(annotators, label_mapping)
+        self.label_suffixes = label_suffixes
+
+    def add_annotation_prob_labels(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Add annotations as an np array [lab1, lab2, ...].
+
+        Args:
+            df (pd.DataFrame): dataframe with all annotation
+                data to add probability label column to.
+
+        Returns:
+            (pd.DataFrame): dataframe with added labels.
+        """
+        return pd.DataFrame(df.apply(self._add_row_soft_label, axis=1))
+
+    def _add_row_soft_label(self, row) -> pd.Series:
+        for annotator in self.annotators:
+
+            cols_to_check = [f"{annotator}{suffix}" for suffix in self.label_suffixes]
+
+            # check cols are all there
+            if any(col not in row.index for col in cols_to_check):
+                raise ValueError(f"At least one suffix is not in the dataframe for all annotators.")
+            
+            # add label to non-null
+            if row[cols_to_check].notna().all():
+                values_list = [self.label_mapping[val] for val in list(row[cols_to_check])]
+                row[f"{annotator}_label"] = np.array(values_list, dtype=int)
+
+        return row
+    
+    def add_sample_prob_labels(self, df: pd.DataFrame, reliability_dict: dict) -> pd.DataFrame:
+        return df
+
+    def add_sample_hard_labels(self, df: pd.DataFrame) -> pd.DataFrame:
+        return df
+    
+
+

--- a/src/effiara/utils.py
+++ b/src/effiara/utils.py
@@ -31,7 +31,7 @@ def headings_contain_prob_labels(df, heading_1, heading_2, num_classes=3):
     return checks.all(axis=None)
 
 
-def retrieve_pair_annotations(df, user_x, user_y):
+def retrieve_pair_annotations(df, user_x, user_y, suffix="_label"):
     """Get the subset of the dataframe annotated by users
        x and y.
 
@@ -39,13 +39,15 @@ def retrieve_pair_annotations(df, user_x, user_y):
         df (pd.DataFrame): the whole dataset.
         user_x (str): name of the user in the form user_x.
         user_x (str): name of the user in the form user_y.
+        suffix (str): suffix added to usernames, used to
+            find all shared samples.
 
     Returns:
         pd.DataFrame: copy of the reduced subset containing
                       only samples annotated by both users.
     """
-    condition1 = df[f"{user_x}_label"].notna()
-    condition2 = df[f"{user_y}_label"].notna()
+    condition1 = df[f"{user_x}{suffix}"].notna()
+    condition2 = df[f"{user_y}{suffix}"].notna()
     return df[condition1 & condition2].copy()
 
 


### PR DESCRIPTION
* Added ordinal label generator
* Update multi-label agreement to handle ordinal annotations
* Remove beta param from calculate reliabiltiy function (beta = 1 -
  alpha)
* Add option for upper triangle display in Annotations
* Add missing 'self' in DefaultLabelGenerator method
* Update examples to remove num_samples from Annotations

I think some of our formatting differs slightly - I've just use the default isort && black on all the files I work on - can do reformatting in a later issue