### PR TITLE
Label suffix

### DIFF
--- a/docs/source/advanced_usage.rst
+++ b/docs/source/advanced_usage.rst
@@ -1,0 +1,8 @@
+Advanced Usage
+==============
+
+
+.. toctree::
+   :maxdepth: 2
+
+   label_generators

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -16,6 +16,79 @@ In the meantime, you can install EffiARA like so.
    python setup.py develop
 
 
+Fundamentals
+------------
+
+
+Data Format
+...........
+
+EffiARA assumes a common data format for all annotations. This format is a :code:`pandas.DataFrame`
+object with a column for each annotation from each annotator. The column name format for a user's annotations is
+:code:`{username}_label` and each row is a unique sample.
+
+Let's assume we have the following CSV file saved as "example.csv".
+
+
+.. csv-table:: example.csv
+   :header: "Larry_label", "Curly_label", "Moe_label"
+
+   "yes", "no", "yes"
+   "no", "no", 
+   , "yes", "yes"
+   "no", "no", "no"
+
+
+We thus have three annotators --Larry, Curly, and Moe-- and four examples. Our task is binary with 
+"yes" or "no" labels. We also see that some annotators have not annotated some samples. This is fine. 
+EffiARA will account for this when computing agreement. Let's read this data into Python.
+
+.. code-block:: python
+
+   import pandas as pd
+   annotations = pd.read_csv("example.csv")
+   print(annotations)
+
+        Larry_label Curly_label Moe_label
+   0         yes          no       yes
+   1          no          no       NaN
+   2         NaN         yes       yes
+   3          no          no        no
+
+
+Computing Agreement
+...................
+
+Computing agreement between our annotators is done using the `Annotations` class. We simply instantiate
+this class with our annotations DataFrame and get agreements and annotator reliabilities like so.
+
+.. code-block:: python
+
+   from effiara.annotator_reliability import Annotations
+   # overlap_threshold is the minimum number of samples
+   # annotated by a pair of annotators to compute inter-annotator
+   # agreement. It's default is 15, so we need to set it lower
+   # because we only have 4 examples. 
+   annos = Annotations(annotations, overlap_threshold=1)
+   print(annos)
+
+   Node Larry has the following attributes:
+   reliability: 1.040292317713493
+   intra_agreement: 1
+   avg_inter_agreement: 0.5874928354635361
+
+   Node Curly has the following attributes:
+   reliability: 0.8083601730435107
+   intra_agreement: 1
+   avg_inter_agreement: 0.2335628758666486
+
+   Node Moe has the following attributes:
+   reliability: 1.151347509242996
+   intra_agreement: 1
+   avg_inter_agreement: 0.7569637792475039
+
+
+
 Minimum Working Example
 -----------------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ and computing reliability using inter- and intra-annotator agreement.
    :caption: Contents:
 
    getting_started
-   label_generators
+   advanced_usage
 
 
 .. toctree::

--- a/examples/minimal.py
+++ b/examples/minimal.py
@@ -50,6 +50,16 @@ effiannos = Annotations(annotations, reannotations=True)
 #                         label_generator=label_generator)
 print(effiannos.get_reliability_dict())
 
+# Get agreement info for annotators like so
+user_info = effiannos["Larry"]
+print(user_info)
+agreement = effiannos["Larry", "Moe"]
+print(agreement)
+
 # Edges are inter-annotator reliability
 # Nodes are intra-annotator reliability
 effiannos.display_annotator_graph()
+
+# The graph isn't very readable with more than 5 or 6 annotators
+# In these cases, we can also plot the agreements as a heatmap.
+effiannos.display_agreement_heatmap()

--- a/src/effiara/agreement.py
+++ b/src/effiara/agreement.py
@@ -279,28 +279,31 @@ def pairwise_agreement(
         df (pd.DataFrame): full dataframe containing the whole dataset.
         user_x (str): name of the user in the form user_x.
         user_y (str): name of the user in the form user_y.
-        metric (str): agreement metric to use for
-                      inter-/intra-annotator agreement:
-            - krippendorff: nominal krippendorff's alpha similarity metric
-                            on hard labels only.
-            - cohen: nominal cohen's kappa similarity metric on hard
-                     labels only.
-            - fleiss: nominal fleiss kappa similarity metric on hard
-                      labels only.
-            - multi_krippendorff: krippendorff similarity by label for
-                                  multilabel classification.
-            - cosine: the cosine similarity metric to be used on soft labels.
-        agreement_type (str):
-            type of agreement:
-                - nominal
-                - ordinal
-                - interval
-                - ratio
+        metric (str): agreement metric to use for inter-/intra-annotator agreement.
+
+            krippendorff: nominal krippendorff's alpha similarity metric on hard labels only.
+
+            cohen: nominal cohen's kappa similarity metric on hard labels only.
+
+            fleiss: nominal fleiss kappa similarity metric on hard labels only.
+
+            multi_krippendorff: krippendorff similarity by label for multilabel classification.
+
+            cosine: the cosine similarity metric to be used on soft labels.
+        agreement_type (str): type of agreement.  * nominal
+
+            * ordinal
+
+            * interval
+
+            * ratio
+
             NOTE: currently only working for multi_krippendorff.
         label_suffix (str): suffix for the label being compared.
 
     Returns:
         float: agreement between user_x and user_y.
+
     """
     pair_df = retrieve_pair_annotations(df, user_x, user_y)
     if metric == "krippendorff":

--- a/src/effiara/annotator_reliability.py
+++ b/src/effiara/annotator_reliability.py
@@ -102,6 +102,18 @@ class Annotations:
         self.calculate_inter_annotator_agreement()
         self.calculate_annotator_reliability(alpha=self.reliability_alpha)
 
+    def __getitem__(self, users):
+        if isinstance(users, str):
+            # Just one user specified
+            item = self.G.nodes()[users]
+        else:
+            if not isinstance(users, (tuple, list)):
+                raise KeyError(str(users))
+            if len(users) > 2:
+                raise ValueError(f"__getitem__ takes one or two users.")
+            item = self.G.edges()[users]
+        return item
+
     def replace_labels(self):
         """Merge labels. Uses find and replace so do not switch labels e.g.
         {"misinfo": ["debunk"], "debunk": ["misinfo", "other"]}.
@@ -201,6 +213,7 @@ class Annotations:
                     num_classes=self.num_classes,
                     metric=self.agreement_metric,
                     agreement_type=self.agreement_type,
+                    label_suffix=self.agreement_suffix
                 )
 
         # add all agreement scores to the graph
@@ -230,6 +243,7 @@ class Annotations:
                         num_classes=self.num_classes,
                         metric=self.agreement_metric,
                         agreement_type=self.agreement_type,
+                        label_suffix=self.agreement_suffix
                     )
                 except KeyError:
                     warnings.warn(


### PR DESCRIPTION
agreement_suffix in the Annotations class wasn't used when computing agreement, which meant that metrics could only use columns with the _label suffix. I also added a __getitem__ method to Annotations to allow easy lookup by username.

Now you can do the following. E.g., for a dataset with probabilistic labels.

```python
annotations = Annotations(df, agreement_metric="cosine", agreement_suffix="_prob")
print(annotations["user_1"])
{'reliability': 1.5006459532025977,
 'intra_agreement': np.float64(0.7873053892215569),
 'avg_inter_agreement': np.float64(0.41091713855213263)}

print(annotations["user_1", "user_2"])
{'agreement': np.float64(0.38169048195689026)}
```

I accidentally included recent changes from a documentation branch. Feel free to ignore commits 5839c28 and 8b962d4.