### PR TITLE
Add overall Krippenorff's alpha calculation.

### DIFF
--- a/examples/synthetic_single_label.py
+++ b/examples/synthetic_single_label.py
@@ -47,6 +47,7 @@ print(annotations)
 label_mapping = {0.0: 0, 1.0: 1, 2.0: 2}
 label_generator = EffiLabelGenerator(sample_distributor.annotators, label_mapping)
 effiannos = Annotations(annotations, label_generator, reannotations=True)
+print(effiannos.calculate_overall_inter_annnotator_agreement())
 print(effiannos.get_reliability_dict())
 effiannos.display_annotator_graph()
 # Equivalent to the graph, but as a heatmap

--- a/src/effiara/agreement.py
+++ b/src/effiara/agreement.py
@@ -8,6 +8,34 @@ from statsmodels.stats.inter_rater import aggregate_raters, fleiss_kappa
 from effiara.utils import headings_contain_prob_labels, retrieve_pair_annotations
 
 
+def inter_annotator_agreement_krippendorff(df, label_cols, label_mapping):
+    """Calculate overall Krippendorff's alpha inter-annotator agreement
+    metric.
+
+    Args:
+        df (pd.DataFrame): dataframe containing all labels.
+        label_cols (List[str]): annotators' label columns to calculate
+            agreement among.
+        label_mapping (dict): mapping between labels in datasets to numeric
+            label.
+
+    Returns:
+        float: Krippendorff's alpha agreement metric.
+    """
+    # add numeric version of each label col with label mapping
+    num_label_cols = [f"{label_col}_numeric" for label_col in label_cols]
+    for num_label_col, label_col in zip(num_label_cols, label_cols):
+        df[num_label_col] = df[label_col].map(label_mapping)
+
+    # all label cols _numeric .to_numpy()
+    krippendorff_format_data = df[num_label_cols].to_numpy().T
+
+    # run krippendorff's alpha
+    return krippendorff.alpha(
+        reliability_data=krippendorff_format_data, level_of_measurement="nominal"
+    )
+
+
 def pairwise_nominal_krippendorff_agreement(
     pair_df, heading_1, heading_2, label_mapping
 ):
@@ -339,7 +367,7 @@ def pairwise_agreement(
         float: agreement between user_x and user_y.
 
     """
-    pair_df = retrieve_pair_annotations(df, user_x, user_y)
+    pair_df = retrieve_pair_annotations(df, user_x, user_y, suffix=label_suffix)
     if metric == "krippendorff":
         return pairwise_nominal_krippendorff_agreement(
             pair_df, user_x + label_suffix, user_y + label_suffix, label_mapping

--- a/src/effiara/annotator_reliability.py
+++ b/src/effiara/annotator_reliability.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 
-from effiara.agreement import pairwise_agreement
+from effiara.agreement import inter_annotator_agreement_krippendorff, pairwise_agreement
 from effiara.label_generators import DefaultLabelGenerator, LabelGenerator
 from effiara.utils import retrieve_pair_annotations
 
@@ -95,7 +95,7 @@ class Annotations:
         self.strength = strength
 
         # set in self.calculate_inter_annotator_agreement
-        self.overall_inter_annotator_agreement = np.nan
+        self.avg_inter_annotator_agreement = np.nan
 
         # merge labels
         self.replace_labels()
@@ -191,6 +191,21 @@ class Annotations:
                 np.exp(self.G.nodes[node][property]) * num_nodes / denominator
             )
 
+    def calculate_overall_inter_annnotator_agreement(self):
+        """Calculate the overall inter-annotator agreement metric
+        for the whole dataset. Currently only Krippendorff's alpha
+        is implemented.
+        """
+        # TODO: change to logs
+        print(
+            "WARNING: only Krippendorff's alpha is currently implemented for this feature. Reporting Krippendorff's alpha."
+        )
+
+        label_cols = [anno + self.agreement_suffix for anno in self.annotators]
+        return inter_annotator_agreement_krippendorff(
+            self.df, label_cols, self.label_mapping
+        )
+
     def calculate_inter_annotator_agreement(self):
         """Calculate the inter-annotator agreement between each
         pair of annotators. Each agreement value will be
@@ -201,7 +216,7 @@ class Annotations:
         pairs = combinations(self.annotators, 2)
         for current_annotator, link_annotator in pairs:
             pair_df = retrieve_pair_annotations(
-                self.df, current_annotator, link_annotator
+                self.df, current_annotator, link_annotator, suffix=self.agreement_suffix
             )
             if len(pair_df) >= self.overlap_threshold:
                 pair = (current_annotator, link_annotator)
@@ -223,7 +238,7 @@ class Annotations:
         # TODO: maybe add alternative way of anntotator agreement?
         # i.e. Krippendorff for all annotations if individual annotator
         # doesn't matter
-        self.overall_inter_annotator_agreement = np.mean(
+        self.avg_inter_annotator_agreement = np.mean(
             list(inter_annotator_agreement_scores.values())
         )
 
@@ -351,6 +366,23 @@ class Annotations:
             dict: dictionary of key=username, value=reliability.
         """
         return {node: self.G.nodes[node]["reliability"] for node in self.G.nodes()}
+
+    def get_agreement(self, user_1, user_2) -> Optional[float]:
+        """Get the agreement between two annotators.
+
+        Args:
+            user_1 (str): the name of the first annotator.
+            user_2 (str): the name of the second annotator.
+
+        Returns:
+            Optional[float]: agreement between the two annotators (or None).
+        """
+        if user_1 == user_2:
+            return self.G.nodes[user_1].get("intra_agreement")
+        edge_data = self.G.get_edge_data(user_1, user_2)
+        if not edge_data:
+            return None
+        return edge_data.get("agreement", None)
 
     def display_annotator_graph(self, legend=False):
         """Display the annotation graph."""

--- a/src/effiara/label_generators/label_generator.py
+++ b/src/effiara/label_generators/label_generator.py
@@ -94,7 +94,8 @@ class LabelGenerator(ABC):
         self.num_annotators = len(self.annotators)
         self.label_mapping = label_mapping
         self.num_classes = len(label_mapping)
-        if label_suffixes is None:
+        self.label_suffixes = label_suffixes
+        if self.label_suffixes is None:
             self.label_suffixes = ["_label"]
 
     @abstractmethod

--- a/src/effiara/preparation.py
+++ b/src/effiara/preparation.py
@@ -6,7 +6,7 @@ This includes:
 
 import re
 import warnings
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import pandas as pd
 from sympy import Eq, solve, symbols
@@ -219,7 +219,7 @@ class SampleDistributor:
         df: pd.DataFrame,
         save_path: Optional[str] = None,
         all_reannotation: bool = False,
-    ):
+    ) -> Dict[str, pd.DataFrame]:
         """Distribute samples based on sample distributor
            settings.
 


### PR DESCRIPTION
- Add dataset level Krippendorff's alpha calculation (effiara.agreement.inter_annotator_agreement_krippendorff).
- Add dataset-level reliability calculation to effiara.annotator_reliability (calculate_overall_inter_annotator_agreement).
- Fix minor bugs with annotator label suffixes in effiara.annotator_reliability.